### PR TITLE
Add TNTRacers for 1.14

### DIFF
--- a/Source/TNTRacers/TNTRacers_1440p/rules.txt
+++ b/Source/TNTRacers/TNTRacers_1440p/rules.txt
@@ -1,0 +1,22 @@
+[Definition]
+titleIds = 0005000010142800,000500001014F000
+name = "TNT Racers Nitro Machines Edition - 2560x1440"
+version = 2
+
+[TextureRedefine] #TV
+width = 1928
+height = 1088
+overwriteWidth = 2570
+overwriteHeight = 1450
+
+[TextureRedefine] # q-res
+width = 488
+height = 278
+overwriteWidth = 650 
+overwriteHeight = 370 
+
+[TextureRedefine] # gamepad
+width = 862
+height = 488
+#overwriteWidth = 2584 
+#overwriteHeight = 1464

--- a/Source/TNTRacers/TNTRacers_2160p/rules.txt
+++ b/Source/TNTRacers/TNTRacers_2160p/rules.txt
@@ -1,0 +1,22 @@
+[Definition]
+titleIds = 0005000010142800,000500001014F000
+name = "TNT Racers Nitro Machines Edition - 3840x2160"
+version = 2
+
+[TextureRedefine] # tv
+width = 1928
+height = 1088
+overwriteWidth = 3856 
+overwriteHeight = 2176 
+
+[TextureRedefine] # q-res
+width = 488
+height = 278
+overwriteWidth = 976 
+overwriteHeight = 556 
+
+[TextureRedefine] # gamepad
+width = 862
+height = 480
+#overwriteWidth = 3876
+#overwriteHeight = 2196 

--- a/Source/TNTRacers/TNTRacers_2880p/rules.txt
+++ b/Source/TNTRacers/TNTRacers_2880p/rules.txt
@@ -1,0 +1,22 @@
+[Definition]
+titleIds = 0005000010142800,000500001014F000
+name = "TNT Racers Nitro Machines Edition - 5120x2880"
+version = 2
+
+[TextureRedefine] # tv
+width = 1928
+height = 1080
+overwriteWidth = 5141 
+overwriteHeight = 2901 
+
+[TextureRedefine] # q-res
+width = 480
+height = 270
+overwriteWidth = 1280 
+overwriteHeight = 720 
+
+[TextureRedefine] # gamepad
+width = 854
+height = 480
+#overwriteWidth = 5120 
+#overwriteHeight = 2880 

--- a/Source/TNTRacers/TNTRacers_30FPS/rules.txt
+++ b/Source/TNTRacers/TNTRacers_30FPS/rules.txt
@@ -1,0 +1,10 @@
+[Definition]
+titleIds = 0005000010142800,000500001014F000
+name = "TNT Racers Nitro Machines Edition - 30FPS Lock"
+# Without it the game goes at twice the actual speed.
+version = 2
+
+[Control]
+vsyncFrequency = 30
+
+

--- a/Source/TNTRacers/TNTRacers_480p/rules.txt
+++ b/Source/TNTRacers/TNTRacers_480p/rules.txt
@@ -1,0 +1,22 @@
+[Definition]
+titleIds = 0005000010142800,000500001014F000
+name = "TNT Racers Nitro Machines Edition - 854x480"
+version = 2
+
+[TextureRedefine] # tv
+width = 1928
+height = 1088
+overwriteWidth = 857 
+overwriteHeight = 483 
+
+[TextureRedefine] # q-res
+width = 488
+height = 278
+overwriteWidth = 218 
+overwriteHeight = 124 
+
+[TextureRedefine] # gamepad
+width = 862
+height = 488
+#overwriteWidth = 854 
+#overwriteHeight = 488 

--- a/Source/TNTRacers/TNTRacers_720p/rules.txt
+++ b/Source/TNTRacers/TNTRacers_720p/rules.txt
@@ -1,0 +1,22 @@
+[Definition]
+titleIds = 0005000010142800,000500001014F000
+name = "TNT Racers Nitro Machines Edition - 1280x720"
+version = 2
+
+[TextureRedefine] # tv
+width = 1928
+height = 1080
+overwriteWidth = 1285 
+overwriteHeight = 725 
+
+[TextureRedefine] # q-res
+width = 480
+height = 270
+overwriteWidth = 325 
+overwriteHeight = 185 
+
+[TextureRedefine] # gamepad
+width = 862
+height = 488
+#overwriteWidth = 1291 
+#overwriteHeight = 732 

--- a/Source/TNTRacers/TNTRacers_900p/rules.txt
+++ b/Source/TNTRacers/TNTRacers_900p/rules.txt
@@ -1,0 +1,22 @@
+[Definition]
+titleIds = 0005000010142800,000500001014F000
+name = "TNT Racers Nitro Machines Edition - 1600x900"
+version = 2
+
+[TextureRedefine] # tv
+width = 1928
+height = 1080
+overwriteWidth = 1607 
+overwriteHeight = 907 
+
+[TextureRedefine] # q-res
+width = 488
+height = 270
+overwriteWidth = 407 
+overwriteHeight = 232 
+
+[TextureRedefine] # gamepad
+width = 862
+height = 480
+#overwriteWidth = 1614 
+#overwriteHeight = 915 


### PR DESCRIPTION
1.13 version doesn't scaled correctly on Cemu 1.14.
as per Exzap mentioned, the resolutions needed to be 'rounded' so I made the corrections and tested them.
also added a 30FPS Lock Pack since the game on 1.14 goes 2times faster then on 1.13.*