### PR TITLE
"Default" entry cosmetic fix to BotW Divine Laser Beams Customizer

### DIFF
--- a/Modifications/BreathOfTheWild_DivineLaserBeamCustomizer/rules.txt
+++ b/Modifications/BreathOfTheWild_DivineLaserBeamCustomizer/rules.txt
@@ -6,7 +6,7 @@ description = Allows customization of the color of the Divine Beasts's Laser Bea
 version = 3
 
 [Preset]
-name = (Default)Red
+name = Red (Default)
 $hue:int = 0
 $rainbow:int = 0
 $disableBeams:int = 0


### PR DESCRIPTION
The (Default) entry is now formatted in the same way as the other packs